### PR TITLE
supress messages from tensor flow

### DIFF
--- a/MyBot.py
+++ b/MyBot.py
@@ -3,6 +3,8 @@ import os
 import sys
 import numpy as np
 
+os.environ["TF_CPP_MIN_LOG_LEVEL"]="2" # supress most messages from tensorflow
+
 VISIBLE_DISTANCE = 4
 input_dim=4*(2*VISIBLE_DISTANCE+1)*(2*VISIBLE_DISTANCE+1)
 


### PR DESCRIPTION
When I ran the bot, tensor flow continued to output messages to the stdout even though it is redirected.  This environmental variable will stop the messages from tensorflow below ERROR level.  It is available in the current version you get when you use Pip3.